### PR TITLE
Improved dedu logging

### DIFF
--- a/plugins/sk-internal-order-system-dedu/includes/class-sk-dedu-ws.php
+++ b/plugins/sk-internal-order-system-dedu/includes/class-sk-dedu-ws.php
@@ -54,8 +54,12 @@ class Sk_DeDU_WS {
 		if ( $session_key = $this->authenticate() ) {
 			$this->ws_session_key = $session_key;
 		} else {
-			// Throw an exception for invalid credentials.
-			throw new Exception( 'The credentials you provided seems to be wrong.' );
+			// Log it.
+			SKW()->log( __( 'SK_DeDU: Det gick inte att autensiera med DeDU. Var vänlig kontrollera att uppgifterna stämmer.', 'sk-dedu' ), E_WARNING );
+
+			// Throw a general exception since this might
+			// end up in the front-end.
+			throw new Exception( __( 'Något gick fel vid beställningen.', 'sk-dedu' ) );
 		}
 	}
 


### PR DESCRIPTION
Ändrade följande vid fel vid autentisering mot DeDU:

* Meddelandet för undantaget är mer generellt nu eftersom det kan komma ut till front-end.
* Loggar till `error_log` att autentisering misslyckats.