### PR TITLE
Fix: encode special characters to output valid XML

### DIFF
--- a/plugins/sk-internal-order-system-dedu/includes/class-sk-dedu-xml.php
+++ b/plugins/sk-internal-order-system-dedu/includes/class-sk-dedu-xml.php
@@ -164,7 +164,7 @@ class Sk_DeDU_XML {
 			}
 		}
 
-		return $str;
+		return htmlspecialchars( $str );
 	}
 
 	/**
@@ -200,7 +200,7 @@ class Sk_DeDU_XML {
 
 		// Add billing address.
 		$string .= sprintf( __( "Fakturaadress (gäller endast vid extern faktura): %s\n", 'sk-dedu' ), '' );
-		return $string;
+		return htmlspecialchars( $string );
 	}
 
 }


### PR DESCRIPTION
Kör fritextfälten som går in i DeDU via `htmlspecialchars()` för att få ut godkänd XML även vid produktnamn osv med specialtecken.