### PR TITLE
December updates

### DIFF
--- a/plugins/sk-csv-importer/sk-csv-importer.php
+++ b/plugins/sk-csv-importer/sk-csv-importer.php
@@ -16,9 +16,6 @@
  * Developer URI:	http://www.fmca.se/
  * Text Domain:		sk-csvimporter
  * Domain Path:		/languages
- * Copyright:       © 2009-2015 WooThemes.
- * License:         GNU General Public License v3.0
- * License URI:     http://www.gnu.org/licenses/gpl-3.0.html
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/sk-internal-order-system-dedu/includes/class-sk-dedu-ws.php
+++ b/plugins/sk-internal-order-system-dedu/includes/class-sk-dedu-ws.php
@@ -27,13 +27,13 @@ class Sk_DeDU_WS {
 	 * The URL for the login endpoint of WebService.
 	 * @var string
 	 */
-	private static $ws_login_url = '/Login?%s';
+	private $ws_login_url = '/Login?%s';
 
 	/**
 	 * The URL for the endpoint for creating tasks.
 	 * @var string
 	 */
-	private static $ws_create_task_url = '/TemplatedXML?TemplateName=Sundsvall_CreateWebShopTaskFromList&SessionKey=%s';
+	private $ws_create_task_url = '/TemplatedXML?TemplateName=Sundsvall_CreateWebShopTaskFromList&SessionKey=%s';
 
 	/**
 	 * Authenticates with the WebService on construct.
@@ -43,8 +43,8 @@ class Sk_DeDU_WS {
 	 */
 	public function __construct( $base_url, $username, $password ) {
 		// Set URLs.
-		self::$ws_login_url = untrailingslashit( $base_url ) . self::$ws_login_url;
-		self::$ws_create_task_url = untrailingslashit( $base_url ) . self::$ws_create_task_url;
+		$this->ws_login_url = untrailingslashit( $base_url ) . $this->ws_login_url;
+		$this->ws_create_task_url = untrailingslashit( $base_url ) . $this->ws_create_task_url;
 
 		// Set credentials as class properties.
 		$this->ws_username = $username;
@@ -72,7 +72,7 @@ class Sk_DeDU_WS {
 	public function send_order( WC_Order $order, $order_items ) {
 		// Init cURL.
 		$ch = curl_init();
-		curl_setopt( $ch, CURLOPT_URL, sprintf( self::$ws_create_task_url, $this->ws_session_key ) );
+		curl_setopt( $ch, CURLOPT_URL, sprintf( $this->ws_create_task_url, $this->ws_session_key ) );
 		curl_setopt( $ch, CURLOPT_POST, true );
 		curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );
 		curl_setopt( $ch, CURLOPT_HEADER, true );
@@ -122,7 +122,7 @@ class Sk_DeDU_WS {
 		$ch = curl_init();
 
 		// Set URL.
-		curl_setopt( $ch, CURLOPT_URL, sprintf( self::$ws_login_url, $this->generate_login_params() ) );
+		curl_setopt( $ch, CURLOPT_URL, sprintf( $this->ws_login_url, $this->generate_login_params() ) );
 
 		// Return as string instead of echo.
 		curl_setopt( $ch, CURLOPT_RETURNTRANSFER, true );

--- a/plugins/sk-internal-order-system-dedu/includes/class-sk-dedu-xml.php
+++ b/plugins/sk-internal-order-system-dedu/includes/class-sk-dedu-xml.php
@@ -199,7 +199,7 @@ class Sk_DeDU_XML {
 			$order->billing_city );
 
 		// Add billing address.
-		$string .= sprintf( __( "Fakturaadress (gäller endast vid extern faktura): %s", 'sk-dedu' ), '' );
+		$string .= sprintf( __( "Fakturaadress (gäller endast vid extern faktura): %s\n", 'sk-dedu' ), '' );
 		return $string;
 	}
 

--- a/plugins/sk-internal-order-system-dedu/includes/class-sk-dedu-xml.php
+++ b/plugins/sk-internal-order-system-dedu/includes/class-sk-dedu-xml.php
@@ -184,22 +184,22 @@ class Sk_DeDU_XML {
 		// Add phone.
 		$string .= sprintf( __( "Telefon: %s\n", 'sk-dedu' ), $order->billing_phone );
 
+		// Add company
+		$string .= sprintf( __( "Förvaltning: %s\n", 'sk-dedu' ), $order->billing_company );
+
 		// Add customer message (order comment).
 		$string .= sprintf( __( "Kommentar: %s\n", 'sk-dedu' ), $order->customer_message );
 
 		// Add shipping address.
-		$string .= sprintf( __( "Leveransadress: %s\n%s\n%s %s\n", 'sk-dedu' ),
-			$order->billing_company,
+		$string .= sprintf( __( "Leveransadress:\n%s\n%s\n%s\n%s %s\n", 'sk-dedu' ),
+			$order->get_meta('_billing_organization', true),
+			$order->get_meta('_billing_department', true),
 			$order->billing_address_1,
 			$order->billing_postcode,
 			$order->billing_city );
 
 		// Add billing address.
-		$string .= sprintf( __( "Fakturaadress (gäller endast vid extern faktura): %s\n%s\n%s %s\n", 'sk-dedu' ),
-			$order->shipping_company,
-			$order->shipping_address_1,
-			$order->shipping_postcode,
-			$order->shipping_city );
+		$string .= sprintf( __( "Fakturaadress (gäller endast vid extern faktura): %s", 'sk-dedu' ), '' );
 		return $string;
 	}
 

--- a/plugins/sk-internal-order-system-dedu/includes/class-sk-dedu-xml.php
+++ b/plugins/sk-internal-order-system-dedu/includes/class-sk-dedu-xml.php
@@ -163,7 +163,6 @@ class Sk_DeDU_XML {
 				}
 			}
 
-			$str .= "\n";
 		}
 
 		return $str;

--- a/plugins/sk-internal-order/includes/class-skios-gateway.php
+++ b/plugins/sk-internal-order/includes/class-skios-gateway.php
@@ -244,7 +244,7 @@ class SKIOS_Gateway extends WC_Payment_Gateway {
 			$order->update_status( 'wc-internal-order', __( 'Orderinfo skickat till produkternas ägare.', 'skios' ) );
 
 			// Reduce stock levels.
-			$order->reduce_order_stock();
+			wc_reduce_stock_levels( $order->get_id() );
 
 			// Remove cart unless cart is null.
 			if ( isset( $woocommerce->cart ) ) {

--- a/plugins/sk-internal-order/includes/skios-product-owner-functions.php
+++ b/plugins/sk-internal-order/includes/skios-product-owner-functions.php
@@ -211,7 +211,7 @@ function skios_handle_order_notifications( $order, $sorted_items ) {
 				 * @param array    $items           The order items that belongs to this product owner.
 				 */
 				if ( ! is_wp_error( $result = apply_filters( 'skios_order_notification', true, $owner[ 'type' ], $owner, $order, $item->items ) ) ) {
-					$successful_filters[ $owner_id ] = $item->items;
+					$successful_filters[ $item->owner_id ] = $item->items;
 				} else {
 					return $result;
 				}

--- a/plugins/sk-internal-order/includes/skios-product-owner-functions.php
+++ b/plugins/sk-internal-order/includes/skios-product-owner-functions.php
@@ -195,7 +195,7 @@ function skios_handle_order_notifications( $order, $sorted_items ) {
 
 			if ( 0 === $item->owner_id ) {
 				// No owner associated with the id, send to admin.
-				skios_no_owner_email( get_bloginfo( 'admin_email' ), $order, $$item->items );
+				skios_no_owner_email( get_bloginfo( 'admin_email' ), $order, $item->items );
 			} else {
 				$owner = skios_get_product_owner_by_id( $item->owner_id );
 

--- a/plugins/sk-internal-order/sk-internal-order.php
+++ b/plugins/sk-internal-order/sk-internal-order.php
@@ -16,9 +16,6 @@
  * Developer URI:	utveckling.sundsvall.se
  * Text Domain:		skio
  * Domain Path:		/languages
- * Copyright:       © 2009-2015 WooThemes.
- * License:         GNU General Public License v3.0
- * License URI:     http://www.gnu.org/licenses/gpl-3.0.html
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/sk-smex/sk-smex.php
+++ b/plugins/sk-smex/sk-smex.php
@@ -16,9 +16,6 @@
  * Developer URI:	http://www.fmca.se/
  * Text Domain:		sk-smex
  * Domain Path:		/languages
- * Copyright:       © 2009-2015 WooThemes.
- * License:         GNU General Public License v3.0
- * License URI:     http://www.gnu.org/licenses/gpl-3.0.html
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/sk-webshop/includes/class-sk-gf-privacy.php
+++ b/plugins/sk-webshop/includes/class-sk-gf-privacy.php
@@ -1,0 +1,84 @@
+<?php
+class SK_GF_Privacy {
+
+	public function __construct() {
+		add_filter( 'gform_form_settings_menu', array( $this, 'gf_privacy_menu_item' ) );
+		add_action( 'gform_form_settings_page_privacy_settings_page', array( $this, 'gf_privacy_settings_page' ) );
+		add_action( 'gform_after_submission', array( $this, 'delete_post_content' ), 10, 2 );
+	}
+
+	function gf_privacy_menu_item( $menu_items ) {
+
+		$menu_items[] = array(
+			'name' => 'privacy_settings_page',
+			'label' => __( 'Sekretess' )
+		);
+
+		return $menu_items;
+	}
+
+
+	function gf_privacy_settings_page() {
+
+		GFFormSettings::page_header();
+
+		$form_id       = rgget( 'id' );
+		$form          = RGFormsModel::get_form_meta( $form_id );
+		$update_result = array();
+
+		if ( rgpost( 'save' ) ) {
+
+			// Die if not posted from correct page
+			check_admin_referer( "gform_save_form_settings_{$form_id}", 'gform_privacy_settings' );
+
+			$is_privacy = rgpost('form_is_privacy') ? true : false;
+
+			update_post_meta( $form_id, 'is_privacy', $is_privacy );
+
+		}
+
+		echo '<form action="" method="post" id="gform_privacy_settings">';
+
+		echo '<h2>Sekretess</h2>';
+
+		echo '<div>';
+
+		$selected = get_post_meta( $form_id, 'is_privacy', true ) == true ? 'checked="checked"' : '';
+
+		echo '<input type="checkbox" id="form_is_privacy" name="form_is_privacy" ' . $selected . ' />';
+
+		echo '<label for="form_is_privacy"> Rensa data när mejl har skickats</label>';
+
+		echo '</div>';
+
+		?>
+		 <p class="submit">
+				<input type="submit" name="save" value="<?php _e( 'Save', 'gravityforms' ); ?>" class="button-primary">
+			</p>
+
+			<?php wp_nonce_field( "gform_save_form_settings_{$form_id}", 'gform_privacy_settings' ); ?>
+
+			<input type="hidden" id="gform_meta" name="gform_meta" />
+
+		<?php
+
+		echo '</form>';
+
+		GFFormSettings::page_footer();
+
+	}
+
+	function delete_post_content( $entry, $form ) {
+
+		$post_id = $entry['id'];
+
+		$is_privacy = get_post_meta( $form['id'], 'is_privacy', true );
+
+		if ( $is_privacy !== '1' ) return;
+
+		GFAPI::delete_entry( $entry['id'] );
+
+	}
+
+
+}

--- a/plugins/sk-webshop/includes/class-sk-gf-privacy.php
+++ b/plugins/sk-webshop/includes/class-sk-gf-privacy.php
@@ -76,7 +76,42 @@ class SK_GF_Privacy {
 
 		if ( $is_privacy !== '1' ) return;
 
-		GFAPI::delete_entry( $entry['id'] );
+    // Uncomment the following two lines to delete the entry instead of modifying it.
+    // GFAPI::delete_entry( $entry['id'] );
+    // return;
+
+    $updated_entry = $entry;
+
+    $allowed_values = array(
+      'id',
+      'form_id',
+      'date_created',
+      'is_read',
+      'source_url',
+      'post_id',
+      'currency',
+      'payment_status',
+      'payment_date',
+      'transaction_id',
+      'payment_amount',
+      'payment_method',
+      'is_fulfilled',
+      'transaction_type',
+      'status'
+    );
+
+    foreach ( $updated_entry as $key => $value ) {
+      if (!in_array( $key, $allowed_values )) {
+        $updated_entry[$key] = 'Sekretess';
+      }
+
+      // Set user ID to a high integer probably not used by any user.
+      if ( $key == 'created_by') {
+        $updated_entry[$key] = '2000000000';
+      }
+    }
+
+		GFAPI::update_entry( $updated_entry, $entry['id'] );
 
 	}
 

--- a/plugins/sk-webshop/includes/class-sk-webshop-checkout-fields.php
+++ b/plugins/sk-webshop/includes/class-sk-webshop-checkout-fields.php
@@ -156,8 +156,6 @@ class SK_Webshop_Checkout_Fields {
 					}
 				}
 
-				console.log( $( 'h3[data-added=true]' ).length <= numOfExpectedTitles );
-
 				// Check if we have already added the header.
 				if ( $( 'h3[data-added=true]' ).length <= numOfExpectedTitles ) {
 					clearTimeout( timer );

--- a/plugins/sk-webshop/includes/class-sk-webshop-checkout-fields.php
+++ b/plugins/sk-webshop/includes/class-sk-webshop-checkout-fields.php
@@ -116,21 +116,60 @@ class SK_Webshop_Checkout_Fields {
 
 			jQuery( document.body ).on( 'country_to_state_changing', function() {
 				var $ = jQuery;
+				var numOfExpectedTitles = 0;
+
+				var $shipping_title = $( '<h3 data-added="true">Leveransadress</h3>' );
+				var shipping_fields = [
+					'billing_organization',
+					'billing_department',
+					'billing_address_1',
+					'billing_postcode',
+					'billing_city',
+				];
+				var $the_shipping_field = '';
+
+				var $billing_title = $( '<h3 data-added="true">Faktureringsuppgifter</h3>' );
+				var billing_fields = [
+					'billing_reference_number',
+					'billing_responsibility_number',
+					'billing_occupation_number',
+					'billing_activity_number',
+					'billing_project_number',
+					'billing_object_number',
+				];
+				var $the_billing_field = '';
+
+				for (var i = 0; i <= shipping_fields.length; i++) {
+					if ( $( '#' + shipping_fields[i] ).length > 0 ) {
+						numOfExpectedTitles++;
+						$the_shipping_field = $( '#' + shipping_fields[i] );
+						break;
+					}
+				}
+
+				for (var i = 0; i <= billing_fields.length; i++) {
+					if ( $( '#' + billing_fields[i] ).length > 0 ) {
+						console.log( 'dsadsds' );
+						numOfExpectedTitles++;
+						$the_billing_field = $( '#' + billing_fields[i] );
+						break;
+					}
+				}
+
+				console.log( $( 'h3[data-added=true]' ).length <= numOfExpectedTitles );
 
 				// Check if we have already added the header.
-				if ( $( 'h3[data-added=true]' ).length === 2 ) {
+				if ( $( 'h3[data-added=true]' ).length <= numOfExpectedTitles ) {
 					clearTimeout( timer );
 				}
 
 				timer = setTimeout( function() {
-					var $country = $( '#billing_country_field' ),
-						$reference_number = $( '#billing_reference_number_field' ),
-						$shippingTitle = $( '<h3 data-added="true">Leveransadress</h3>' ),
-						$billingTitle = $( '<h3 data-added="true">Faktureringsuppgifter</h3>' );
+					if ( $the_shipping_field.length > 0 ) {
+						$the_shipping_field.parent().before( $shipping_title );
+					}
 
-					if ( $( 'h3[data-added=true]' ).length < 2 ) {
-						$country.before( $shippingTitle );
-						$reference_number.before( $billingTitle );
+					if ( $the_billing_field.length > 0 ) {
+						$the_billing_field.parent().before( $billing_title );
 					}
 				}, 100 );
 			} );

--- a/plugins/sk-webshop/includes/class-sk-webshop-checkout-fields.php
+++ b/plugins/sk-webshop/includes/class-sk-webshop-checkout-fields.php
@@ -18,7 +18,6 @@ class SK_Webshop_Checkout_Fields {
 	 */
 	public function __construct() {
 		// Change fields.
-		add_filter( 'woocommerce_checkout_fields', array( $this, 'add_fields' ), 10 );
 		add_filter( 'woocommerce_checkout_fields', array( $this, 'change_order_of_fields' ), 15 );
 		add_filter( 'woocommerce_default_address_fields', array( $this, 'change_required' ) );
 		add_filter( 'woocommerce_billing_fields', array( $this, 'change_billing_fields' ), 90 );
@@ -29,31 +28,6 @@ class SK_Webshop_Checkout_Fields {
 		// Add some script for the footer.
 		add_action( 'wp_footer', array( $this, 'inject_scripts' ) );
 	}
-
-	/**
-	 * Add billing department and organization
-	 * @param  array $fields
-	 * @return array
-	 */
-	public function add_fields( $fields ) {
-		// Remove the placeholder on address 2 and set a new label.
-		$fields[ 'billing' ][ 'billing_organization' ] = $fields[ 'billing' ][ 'billing_address_2' ];
-		$fields[ 'billing' ][ 'billing_organization' ][ 'label' ] = __( 'Förvaltning/bolag', 'sk-smex' );
-    $fields[ 'billing' ][ 'billing_organization' ][ 'autocomplete' ] = '';
-    $fields[ 'billing' ][ 'billing_organization' ][ 'placeholder' ] = '';
-    $fields[ 'billing' ][ 'billing_organization' ][ 'required' ] = true;
-
-		$fields[ 'billing' ][ 'billing_department' ] = $fields[ 'billing' ][ 'billing_address_2' ];
-		$fields[ 'billing' ][ 'billing_department' ][ 'label' ] = __( 'Arbetsplats, avdelning, rum' );
-		$fields[ 'billing' ][ 'billing_department' ][ 'autocomplete' ] = '';
-    $fields[ 'billing' ][ 'billing_department' ][ 'placeholder' ] = '';
-    $fields[ 'billing' ][ 'billing_department' ][ 'required' ] = true;
-
-		unset($fields[ 'billing' ][ 'billing_address_2' ]);
-
-		// Return fields.
-		return $fields;
-  }
 
 	/**
 	 * Changes the order.

--- a/plugins/sk-webshop/includes/class-sk-webshop-required-fields.php
+++ b/plugins/sk-webshop/includes/class-sk-webshop-required-fields.php
@@ -185,7 +185,6 @@ class SK_Webshop_Required_Fields {
 			foreach ( $fields['billing'] as $field => $value ) {
 				if ( isset( $_fields[ $field ] ) ) {
 					$required = $_fields[ $field ]['required'];
-					$fields['billing'][ $field ]['required'] = $required;
 
 					if ( ! $required ) {
 						unset( $fields['billing'][ $field ] );
@@ -200,7 +199,6 @@ class SK_Webshop_Required_Fields {
 					$required = $_fields[ $_field ]['required'];
 
 					if ( ! $required ) {
-						$fields[ $field ]['required'] = $required;
 
 						if ( ! $required ) {
 							unset( $fields[ $field ] );

--- a/plugins/sk-webshop/includes/class-sk-webshop-required-fields.php
+++ b/plugins/sk-webshop/includes/class-sk-webshop-required-fields.php
@@ -12,21 +12,45 @@ class SK_Webshop_Required_Fields {
 	 * The post meta key name.
 	 * @var string
 	 */
-	private static $FIELDS_META_KEY = 'sk_checkout_tab_fields';
+	private static $fields_meta_key = 'sk_checkout_tab_fields';
 
 	/**
 	 * The fields that we are interested in.
 	 * @var array
 	 */
-	private $FIELDS = array(
-		'billing_department'		=> array(
-			'label' => 'Arbetsplats, avdelning, rum'
+	private $fields = array(
+		'billing_organization' => array(
+			'label' => 'Förvaltning/bolag',
 		),
-		'billing_address_1'		=> array(
-			'label' => 'Gatuadress'
+		'billing_department' => array(
+			'label' => 'Arbetsplats, avdelning, rum',
 		),
-		'billing_organization'		=> array(
-			'label' => 'Förvaltning/bolag'
+		'billing_address_1' => array(
+			'label' => 'Gatuadress',
+		),
+		'billing_postcode' => array(
+			'label' => 'Postnummer',
+		),
+		'billing_city' => array(
+			'label' => 'Ort',
+		),
+		'billing_reference_number' => array(
+			'label' => 'Referensnummer',
+		),
+		'billing_responsibility_number' => array(
+			'label' => 'Ansvarsnummer',
+		),
+		'billing_occupation_number' => array(
+			'label' => 'Verksamhetsnummer',
+		),
+		'billing_activity_number' => array(
+			'label' => 'Aktivitetsnummer',
+		),
+		'billing_project_number' => array(
+			'label' => 'Projektnummer',
+		),
+		'billing_object_number' => array(
+			'label' => 'Objektsnummer',
 		),
 	);
 
@@ -35,9 +59,9 @@ class SK_Webshop_Required_Fields {
 	 * correct array when all checkboxes are unticked.
 	 * @var array
 	 */
-	private $FIELDS_UNCHECKED = array(
-		'billing_address_1'		=> 'no',
-		'billing_department'		=> 'no'
+	private $fields_unchecked = array(
+		'billing_address_1'  => 'no',
+		'billing_department' => 'no',
 	);
 
 	/**
@@ -47,11 +71,10 @@ class SK_Webshop_Required_Fields {
 		// Change fields.
 		add_filter( 'woocommerce_checkout_fields', array( $this, 'change_required' ), 9999999, 1 );
 		add_filter( 'woocommerce_default_address_fields', array( $this, 'change_required' ), 9999999, 1 );
+
 		// Add the checkout tab to product data tabs.
 		add_filter( 'woocommerce_product_data_tabs', array( $this, 'add_checkout_tab' ), 99, 1 );
-
 		add_action( 'woocommerce_product_data_panels', array( $this, 'add_checkout_tab_fields' ) );
-
 		add_action( 'save_post', array( $this, 'save_checkout_tab_fields' ) );
 	}
 
@@ -62,10 +85,10 @@ class SK_Webshop_Required_Fields {
 	 * @return array
 	 */
 	public function add_checkout_tab( $tabs ) {
-		$tabs[ 'sk-checkout-tab' ] = array(
-			'label'		=> __( 'Kassavy', 'sk-shop' ),
-			'target'	=> 'sk_checkout_product_data_tab',
-			'class'		=> '', // index 'class' must be defined. Docs don't mention why.
+		$tabs['sk-checkout-tab'] = array(
+			'label'  => __( 'Kassavy', 'sk-shop' ),
+			'target' => 'sk_checkout_product_data_tab',
+			'class'  => '', // index 'class' must be defined. Docs don't mention why.
 		);
 
 		return $tabs;
@@ -87,23 +110,22 @@ class SK_Webshop_Required_Fields {
 
 			<?php
 			// Get the saved values.
-		$values = get_post_meta( $post->ID, self::$FIELDS_META_KEY, true );
-
+			$values = get_post_meta( $post->ID, self::$fields_meta_key, true );
 
 			// Create text inputs for each fields.
-			foreach ( $this->FIELDS as $field => $field_data ) {
+			foreach ( $this->fields as $field => $field_data ) {
 				// Check if we have a saved value.
 				$value = ( $values && ! empty( $values[ $field ] ) ) ? $values[ $field ] : 'no';
 
 				// Create field.
 				woocommerce_wp_checkbox( array(
-					'id'			=> self::$FIELDS_META_KEY . '[' . $field . ']',
-					'wrapper_class'	=> 'show_if_simple',
-					'label'			=> $field_data['label'],
-					'description'	=> 'Inaktivera tvingande för ' . $field_data['label'],
-					'default'		=> 'no',
-					'value'			=> $value,
-					'desc_tip'		=> false,
+					'id'            => self::$fields_meta_key . '[' . $field . ']',
+					'wrapper_class' => 'show_if_simple',
+					'label'         => $field_data['label'],
+					'description'   => 'Inaktivera fältet ' . $field_data['label'],
+					'default'       => 'no',
+					'value'         => $value,
+					'desc_tip'      => false,
 				) );
 			}
 			?>
@@ -124,11 +146,11 @@ class SK_Webshop_Required_Fields {
 		}
 
 		// Save values or default value
-		$fields = ( ! empty( $_REQUEST[ self::$FIELDS_META_KEY ] ) ) ? $_REQUEST[ self::$FIELDS_META_KEY ] : '';
-		if( ! empty( $fields ) ) {
-			update_post_meta( $post_id, self::$FIELDS_META_KEY, $fields );
+		$fields = ( ! empty( $_REQUEST[ self::$fields_meta_key ] ) ) ? $_REQUEST[ self::$fields_meta_key ] : '';
+		if ( ! empty( $fields ) ) {
+			update_post_meta( $post_id, self::$fields_meta_key, $fields );
 		} else {
-			update_post_meta( $post_id, self::$FIELDS_META_KEY, $this->FIELDS_UNCHECKED );
+			update_post_meta( $post_id, self::$fields_meta_key, $this->fields_unchecked );
 		}
 	}
 
@@ -138,65 +160,61 @@ class SK_Webshop_Required_Fields {
 	 * @return array
 	 */
 	public function change_required( $fields ) {
-
 		global $woocommerce;
 		$items = $woocommerce->cart->get_cart();
 
-		$_fields = $this->FIELDS;
+		if ( empty( $items ) ) {
+			return $fields;
+		}
 
-		foreach($items as $item => $values) {
+		$_fields = $this->fields;
 
+		foreach ( $items as $item => $values ) {
 			$product_id = $values['product_id'];
-			$opt_fields = (array)get_post_meta( $product_id, self::$FIELDS_META_KEY, true );
+			$opt_fields = (array) get_post_meta( $product_id, self::$fields_meta_key, true );
 
-			$opt_fields = array_filter( $opt_fields, function($v) {
-				return $v == 'yes';
+			$opt_fields = array_filter( $opt_fields, function( $v ) {
+				return 'yes' === $v;
 			});
 
-			foreach ( $_fields as $field => $field_data) {
+			foreach ( $_fields as $field => $field_data ) {
+				$shouldbe_required = array_key_exists( $field, $opt_fields ) ? false : true;
 
-				$shouldbe_required = array_key_exists($field, $opt_fields) ? false : true;
-				$is_required = $field_data['required'] || false;
-
-				if ( $shouldbe_required && !$is_required ) {
-					$_fields[$field]['required'] = true;
-				}
-
+				$_fields[ $field ]['required'] = $shouldbe_required;
 			}
-
 		}
 
-		if (isset($fields['billing'])) {
-
+		if ( isset( $fields['billing'] ) ) {
 			foreach ( $fields['billing'] as $field => $value ) {
-				if(!is_null($_fields[$field])) {
-					$required = $_fields[$field]['required'];
-						$fields['billing'][ $field ][ 'required' ]	= $required;
-						if($required == false) {
-							unset($fields['billing'][ $field ]);
-						}
+				if ( isset( $_fields[ $field ] ) ) {
+					$required = $_fields[ $field ]['required'];
+					$fields['billing'][ $field ]['required'] = $required;
+
+					if ( ! $required ) {
+						unset( $fields['billing'][ $field ] );
 					}
+				}
 			}
-
 		} else {
-
 			foreach ( $fields as $field => $value ) {
 				$_field = substr( $field, 0, 8 ) === 'billing_' ? $field : 'billing_' . $field;
-				if(!is_null($_fields[$_field])) {
-					$required = $_fields[$_field]['required'];
-						if ($required == false) {
-							$fields[ $field ][ 'required' ]	= $required;
-							if($required == false) {
-								unset($fields[ $field ]);
-							}
+
+				if ( isset( $_fields[ $_field ] ) ) {
+					$required = $_fields[ $_field ]['required'];
+
+					if ( ! $required ) {
+						$fields[ $field ]['required'] = $required;
+
+						if ( ! $required ) {
+							unset( $fields[ $field ] );
 						}
 					}
+				}
 			}
-
 		}
 
-			// Return new fields.
-			return $fields;
+		// Return new fields.
+		return $fields;
 	}
 
 }

--- a/plugins/sk-webshop/includes/class-sk-webshop-required-fields.php
+++ b/plugins/sk-webshop/includes/class-sk-webshop-required-fields.php
@@ -34,9 +34,6 @@ class SK_Webshop_Required_Fields {
 		'billing_city' => array(
 			'label' => 'Ort',
 		),
-		'billing_reference_number' => array(
-			'label' => 'Referensnummer',
-		),
 		'billing_responsibility_number' => array(
 			'label' => 'Ansvarsnummer',
 		),

--- a/plugins/sk-webshop/includes/class-sk-webshop.php
+++ b/plugins/sk-webshop/includes/class-sk-webshop.php
@@ -97,6 +97,7 @@ class SK_Webshop {
 	private function includes() {
 		include __DIR__ . '/class-sk-webshop-unittype.php';
 		include __DIR__ . '/class-sk-webshop-checkout-fields.php';
+		include __DIR__ . '/class-sk-gf-privacy.php';
 	}
 
 	/**
@@ -106,6 +107,7 @@ class SK_Webshop {
 	private function init_classes() {
 		$this->taxonomies = new SK_Webshop_Unittype();
 		$this->checkout_fields = new SK_Webshop_Checkout_Fields();
+		$this->gf_privacy = new SK_GF_Privacy();
 	}
 
 	/**

--- a/plugins/sk-webshop/sk-webshop.php
+++ b/plugins/sk-webshop/sk-webshop.php
@@ -16,9 +16,6 @@
  * Developer URI:	http://www.fmca.se/
  * Text Domain:		sk-smex
  * Domain Path:		/languages
- * Copyright:       © 2009-2015 WooThemes.
- * License:         GNU General Public License v3.0
- * License URI:     http://www.gnu.org/licenses/gpl-3.0.html
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/storefront-child/functions.php
+++ b/storefront-child/functions.php
@@ -168,3 +168,9 @@ jQuery(document).ready(function($) {
 }
 
 add_action( 'wp_footer', 'sk_product_tooltip_script' );
+
+/**
+ * Override inline styles from theme customization to prevent it from
+ * being changed.
+ */
+include_once __DIR__.'/inline-styles.php';

--- a/storefront-child/inline-styles.php
+++ b/storefront-child/inline-styles.php
@@ -1,0 +1,280 @@
+<?php
+add_action( 'wp_footer', 'theme_inline_styles');
+
+function theme_inline_styles() {
+
+?>
+
+<style>
+.main-navigation ul li a,
+.site-title a,
+ul.menu li a,
+.site-branding h1 a,
+.site-footer .storefront-handheld-footer-bar a:not(.button),
+button.menu-toggle,
+button.menu-toggle:hover {
+  color: #0a0909;
+}
+
+button.menu-toggle,
+button.menu-toggle:hover {
+  border-color: #0a0909;
+}
+
+.main-navigation ul li a:hover,
+.main-navigation ul li:hover > a,
+.site-title a:hover,
+a.cart-contents:hover,
+.site-header-cart .widget_shopping_cart a:hover,
+.site-header-cart:hover > li > a,
+.site-header ul.menu li.current-menu-item > a {
+  color: #3c3b3b;
+}
+
+table th {
+  background-color: #f8f8f8;
+}
+
+table tbody td {
+  background-color: #fdfdfd;
+}
+
+table tbody tr:nth-child(2n) td {
+  background-color: #fbfbfb;
+}
+
+.site-header,
+.secondary-navigation ul ul,
+.main-navigation ul.menu > li.menu-item-has-children:after,
+.secondary-navigation ul.menu ul,
+.storefront-handheld-footer-bar,
+.storefront-handheld-footer-bar ul li > a,
+.storefront-handheld-footer-bar ul li.search .site-search,
+button.menu-toggle,
+button.menu-toggle:hover {
+  background-color: #f9f9f9;
+}
+
+p.site-description,
+.site-header,
+.storefront-handheld-footer-bar {
+  color: #0a0909;
+}
+
+.storefront-handheld-footer-bar ul li.cart .count,
+button.menu-toggle:after,
+button.menu-toggle:before,
+button.menu-toggle span:before {
+  background-color: #0a0909;
+}
+
+.storefront-handheld-footer-bar ul li.cart .count {
+  color: #f9f9f9;
+}
+
+.storefront-handheld-footer-bar ul li.cart .count {
+  border-color: #f9f9f9;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: #000000;
+}
+
+.widget h1 {
+  border-bottom-color: #000000;
+}
+
+body,
+.secondary-navigation a,
+.onsale,
+.pagination .page-numbers li .page-numbers:not(.current), .woocommerce-pagination .page-numbers li .page-numbers:not(.current) {
+  color: #000000;
+}
+
+.widget-area .widget a,
+.hentry .entry-header .posted-on a,
+.hentry .entry-header .byline a {
+  color: #323232;
+}
+
+a  {
+  color: #a90074;
+}
+
+a:focus,
+.button:focus,
+.button.alt:focus,
+.button.added_to_cart:focus,
+.button.wc-forward:focus,
+button:focus,
+input[type="button"]:focus,
+input[type="reset"]:focus,
+input[type="submit"]:focus {
+  outline-color: #a90074;
+}
+
+button, input[type="button"], input[type="reset"], input[type="submit"], .button, .added_to_cart, .widget a.button, .site-header-cart .widget_shopping_cart a.button {
+  background-color: #a90074;
+  border-color: #a90074;
+  color: #ffffff;
+}
+
+button:hover, input[type="button"]:hover, input[type="reset"]:hover, input[type="submit"]:hover, .button:hover, .added_to_cart:hover, .widget a.button:hover, .site-header-cart .widget_shopping_cart a.button:hover {
+  background-color: #90005b;
+  border-color: #90005b;
+  color: #ffffff;
+}
+
+button.alt, input[type="button"].alt, input[type="reset"].alt, input[type="submit"].alt, .button.alt, .added_to_cart.alt, .widget-area .widget a.button.alt, .added_to_cart, .pagination .page-numbers li .page-numbers.current, .woocommerce-pagination .page-numbers li .page-numbers.current, .widget a.button.checkout {
+  background-color: #2c2d33;
+  border-color: #2c2d33;
+  color: #ffffff;
+}
+
+button.alt:hover, input[type="button"].alt:hover, input[type="reset"].alt:hover, input[type="submit"].alt:hover, .button.alt:hover, .added_to_cart.alt:hover, .widget-area .widget a.button.alt:hover, .added_to_cart:hover, .widget a.button.checkout:hover {
+  background-color: #13141a;
+  border-color: #13141a;
+  color: #ffffff;
+}
+
+#comments .comment-list .comment-content .comment-text {
+  background-color: #f8f8f8;
+}
+
+.site-footer {
+  background-color: #5b1f78;
+  color: #ffffff;
+}
+
+.site-footer a:not(.button) {
+  color: #ffffff;
+}
+
+.site-footer h1, .site-footer h2, .site-footer h3, .site-footer h4, .site-footer h5, .site-footer h6 {
+  color: #ffffff;
+}
+
+#order_review,
+#payment .payment_methods > li .payment_box {
+  background-color: #ffffff;
+}
+
+#payment .payment_methods > li {
+  background-color: #fafafa;
+}
+
+#payment .payment_methods > li:hover {
+  background-color: #f5f5f5;
+}
+
+@media screen and ( min-width: 768px ) {
+  .secondary-navigation ul.menu a:hover {
+    color: #232222;
+  }
+
+  .secondary-navigation ul.menu a {
+    color: #0a0909;
+  }
+
+  .site-header-cart .widget_shopping_cart,
+  .main-navigation ul.menu ul.sub-menu,
+  .main-navigation ul.nav-menu ul.children {
+    background-color: #f1f1f1;
+  }
+}
+
+a.cart-contents,
+.site-header-cart .widget_shopping_cart a {
+  color: #0a0909;
+}
+
+table.cart td.product-remove,
+table.cart td.actions {
+  border-top-color: #ffffff;
+}
+
+.woocommerce-tabs ul.tabs li.active a,
+ul.products li.product .price,
+.onsale,
+.widget_search form:before,
+.widget_product_search form:before {
+  color: #000000;
+}
+
+.woocommerce-breadcrumb a,
+a.woocommerce-review-link,
+.product_meta a {
+  color: #323232;
+}
+
+.onsale {
+  border-color: #000000;
+}
+
+.star-rating span:before,
+.quantity .plus, .quantity .minus,
+p.stars a:hover:after,
+p.stars a:after,
+.star-rating span:before,
+#payment .payment_methods li input[type=radio]:first-child:checked+label:before {
+  color: #a90074;
+}
+
+.widget_price_filter .ui-slider .ui-slider-range,
+.widget_price_filter .ui-slider .ui-slider-handle {
+  background-color: #a90074;
+}
+
+.woocommerce-breadcrumb,
+#reviews .commentlist li .comment_container {
+  background-color: #f8f8f8;
+}
+
+.order_details {
+  background-color: #f8f8f8;
+}
+
+.order_details > li {
+  border-bottom: 1px dotted #e3e3e3;
+}
+
+.order_details:before,
+.order_details:after {
+  background: -webkit-linear-gradient(transparent 0,transparent 0),-webkit-linear-gradient(135deg,#f8f8f8 33.33%,transparent 33.33%),-webkit-linear-gradient(45deg,#f8f8f8 33.33%,transparent 33.33%)
+}
+
+p.stars a:before,
+p.stars a:hover~a:before,
+p.stars.selected a.active~a:before {
+  color: #000000;
+}
+
+p.stars.selected a.active:before,
+p.stars:hover a:before,
+p.stars.selected a:not(.active):before,
+p.stars.selected a.active:before {
+  color: #a90074;
+}
+
+.single-product div.product .woocommerce-product-gallery .woocommerce-product-gallery__trigger {
+  background-color: #a90074;
+  color: #ffffff;
+}
+
+.single-product div.product .woocommerce-product-gallery .woocommerce-product-gallery__trigger:hover {
+  background-color: #90005b;
+  border-color: #90005b;
+  color: #ffffff;
+}
+
+@media screen and ( min-width: 768px ) {
+  .site-header-cart .widget_shopping_cart,
+  .site-header .product_list_widget li .quantity {
+    color: #0a0909;
+  }
+}
+
+</style>
+<?php
+
+}


### PR DESCRIPTION
Innefattar följande:

- Möjlighet att markera att en produkt ska generera unika ordermejl (ärenden) även om det delar produktägare med fler produkter i ordern. Gäller även om fler än 1 av denna vara beställs. (3st mobiltelefoni som tjänst genererar 3st ärenden).
- Ändrat till använda woocommerce nya getter-funktioner för att hämta och påverka order-
 och produktdata.
- Möjlighet att stänga av kassafält på produktnivå. Om alla produkter i ordern valt att stänga av ett visst fält kommer detta inte visas eller krävas i kassan.
- När order misslyckas sätts den till "Misslyckad"
- Möjlighet att trigga att order skickas igen från admin-gränssnittet.
- Bryter ut tema-css till egen fil.