### PR TITLE
Add plugin SK_Clear_Orders

### DIFF
--- a/plugins/sk-clear-orders/includes/class-sk-clear-orders.php
+++ b/plugins/sk-clear-orders/includes/class-sk-clear-orders.php
@@ -24,7 +24,7 @@ class SK_Clear_Orders {
 	 * Constructor.
 	 */
 	function __construct() {
-		add_action( 'wp', [ $this, 'listener' ] );
+		add_action( 'parse_request', [ $this, 'listener' ], 5 );
 	}
 
 	/**

--- a/plugins/sk-clear-orders/includes/class-sk-clear-orders.php
+++ b/plugins/sk-clear-orders/includes/class-sk-clear-orders.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * SK_Clear_Orders
+ * =====
+ *
+ * The main plugin class file.
+ *
+ * @since   20181128
+ * @package 
+ */
+
+defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
+
+class SK_Clear_Orders {
+
+	/**
+	 * Minimium time to keep orders before moving them to trash.
+	 *
+	 * 1 year, 10 months + 1 month in trash + 1 month in backup.
+	 */
+	const TIMELIMIT = MONTH_IN_SECONDS * 22;
+
+	/**
+	 * Constructor.
+	 */
+	function __construct() {
+		add_action( 'wp', [ $this, 'listener' ] );
+	}
+
+	/**
+	 * Our listener that runs certain actions based on GET-parameter.
+	 *
+	 * @return void
+	 */
+	public function listener() {
+		if ( isset( $_GET['clear_orders'] ) ) {
+			switch ( $_GET['clear_orders'] ) {
+				case 'run':
+					$this->clear_orders();
+					break;
+				case 'preview':
+					$this->preview();
+					break;
+			}
+		}
+	}
+
+	/**
+	* Print how many orders exists that are older than the limit.
+	*
+	* @return void
+	*/
+	private function preview() {
+		$orders_to_trash = $this->get_orders_to_trash();
+		$num = count($orders_to_trash);
+
+		printf( _n( "%s order would be trashed.", "%s orders would be trashed.", $num, 'sk-clearorders' ), $num);
+		die();
+	}
+
+	/**
+	* Trash orders that are older than the limit.
+	*
+	* @return void
+	*/
+	private function clear_orders() {
+		$orders_to_trash = $this->get_orders_to_trash();
+
+		$num_trashed = 0;
+
+		foreach( $orders_to_trash as $order ) {
+			if ( wp_trash_post($order) ) {
+				$num_trashed += 1;
+			}
+		}
+
+		printf( _n( "%s order trashed.", "%s orders trashed.", $num_trashed, 'sk-clearorders' ), $num_trashed);
+		die();
+	}
+
+	/**
+	* Get id of orders to trash
+	* 
+	* @param  string $limit Maximum orders to return, default -1 (unlimited)
+	* @return array
+	*/
+	private function get_orders_to_trash( $limit = -1 ) {
+		
+		// Get 10 most recent order ids in date descending order.
+		$query = new WC_Order_Query( array(
+		    'limit' => $limit,
+		    'orderby' => 'date',
+		    'order' => 'DESC',
+		    'return' => 'ids',
+		    'date_created' => '<' . ( time() - self::TIMELIMIT ),
+		) );
+		$orders = $query->get_orders();
+
+		return $orders;
+
+	}
+
+}

--- a/plugins/sk-clear-orders/sk-clear-orders.php
+++ b/plugins/sk-clear-orders/sk-clear-orders.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Sundsvall Kommun Clear Orders Function
+ *
+ * @link     http://www.fmca.se/
+ * @package
+ *
+ * @wordpress-plugin
+ * Plugin Name:		SK Clear Orders
+ * Plugin URI:		utveckling.sundsvall.se
+ * Description:		Provides functionality to clear old orders from WooCommerce.
+ * Version:			20181128
+ * Author:			SK/FMCA
+ * Author URI:		http://www.fmca.se/
+ * Developer:		FMCA
+ * Developer URI:	utveckling.sundsvall.se
+ * Text Domain:		sk-clearorders
+ * Domain Path:		/languages
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if acccessed directly.
+}
+
+// Include main plugin class.
+require_once __DIR__ . '/includes/class-sk-clear-orders.php';
+$skios = new SK_Clear_Orders();


### PR DESCRIPTION
När pluginet är aktiverat finns två url-parametrar:

`/?clear_orders=preview` visar hur många ordrar som skulle flyttas till papperskorgen men gör inget mer än så.

`/?clear_orders=run` kör funktionen och flyttar gamla ordrar till papperskorgen.

Dessa kan ni alltså anropa med cron i de intervaller ni vill (t.ex. varje timme).

----

Vi har byggt funktionen så ordrarna hamnar i papperskorgen istället för att tas bort direkt, detta för att kunna se vilka som tagits bort i felsökningssyfte och som en extra backup. Som standard i WP försvinner poster ur papperskorgen efter en månad. Vi har därför ställt in pluginet att ta bort ordrar som är 1 år och 10 månader gamla. ( + 1 månad i papperskorgen + 1 månad i er backup = 2 år ). Detta kan självklart anpassas.