### PR TITLE
Run forcelogin on parse_request action instead of init

### DIFF
--- a/plugins/sk-webshop/includes/class-sk-webshop.php
+++ b/plugins/sk-webshop/includes/class-sk-webshop.php
@@ -75,7 +75,7 @@ class SK_Webshop {
       return 'Tack för din beställning! Ett ärendenummer kommer att skickas till din e-post inom kort.';
     }, 10, 1 );
 
-		add_action('init', array( $this, 'forcelogin' ));
+		add_action('parse_request', array( $this, 'forcelogin' ), 10);
 
 		// Include all class files.
 		$this->includes();


### PR DESCRIPTION
Lyckades återskapa fel med searchWP-indexeringen lokalt och det hade att göra med att sidan tvingar till inloggning, löstes genom att lägga funktionen på en action senare än searchWP.
Detta löste felet vi lyckades återskapa, så testa om det var samma fel hos er. 