### PR TITLE
Remove inactive users

### DIFF
--- a/plugins/sk-remove-inactive-users/includes/class-sk-remove-inactive-users.php
+++ b/plugins/sk-remove-inactive-users/includes/class-sk-remove-inactive-users.php
@@ -46,8 +46,10 @@ class SK_Remove_Inactive_Users {
 	 *
 	 * @return array
 	 */
-	private function get_all_users() {
-		$args = array();
+	private function get_all_subscribers() {
+		$args = array(
+			'role' => 'subscriber',
+		);
 		return get_users( $args );
 	}
 
@@ -72,7 +74,7 @@ class SK_Remove_Inactive_Users {
 	 * @return void
 	 */
 	private function queue_inactive_users() {
-		$users = $this->get_all_users();
+		$users = $this->get_all_subscribers();
 		foreach ( $users as $user ) {
 			$this->check_user_against_smex( $user );
 		}
@@ -144,6 +146,14 @@ class SK_Remove_Inactive_Users {
 	 */
 	private function delete_user( $user ) {
 		require_once(ABSPATH.'wp-admin/includes/user.php');
-		return wp_delete_user( $user->ID );
+
+		// Reassign content to wpadmin
+		$reasign = null;
+		$wpadmin = get_user_by( 'login', 'wpadmin' );
+		if ( $wpadmin ) {
+			$reassign = $wpadmin->ID;
+		}
+
+		return wp_delete_user( $user->ID, $reassign );
 	}
 }

--- a/plugins/sk-remove-inactive-users/includes/class-sk-remove-inactive-users.php
+++ b/plugins/sk-remove-inactive-users/includes/class-sk-remove-inactive-users.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * SK_Remove_Inactive_Users
+ * =====
+ *
+ * The main plugin class file.
+ *
+ * @since   20181210
+ * @package 
+ */
+
+defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
+
+class SK_Remove_Inactive_Users {
+
+	private $num_queued_users = 0;
+	private $num_deleted_users = 0;
+
+	/**
+	 * Constructor.
+	 */
+	function __construct() {
+		add_action( 'parse_request', [ $this, 'listener' ], 5 );
+	}
+
+	/**
+	 * Our listener that runs certain actions based on GET-parameter.
+	 *
+	 * @return void
+	 */
+	public function listener() {
+		if ( isset( $_GET['remove_inactive_users'] ) ) {
+			switch ( $_GET['remove_inactive_users'] ) {
+				case 'setup':
+					$this->queue_inactive_users();
+					break;
+				case 'delete':
+					$this->delete_queued_users();
+					break;
+			}
+		}
+	}
+
+	/**
+	 * Get all WP-Users
+	 *
+	 * @return array
+	 */
+	private function get_all_users() {
+		$args = array();
+		return get_users( $args );
+	}
+
+	/**
+	 * Get all WP-Users that was queued for deletion 2 weeks ago.
+	 *
+	 * @return array
+	 */
+	private function get_users_for_deletion() {
+		$args = array(
+			'meta_key' => '_user_deletion_queue',
+			'meta_value' => strtotime('-2 weeks'),
+			'meta_compare' => '<'
+		);
+
+		return get_users( $args );
+	}
+
+	/**
+	 * Setup users for deletion if not present in smex.
+	 * 
+	 * @return void
+	 */
+	private function queue_inactive_users() {
+		$users = $this->get_all_users();
+		foreach ( $users as $user ) {
+			$this->check_user_against_smex( $user );
+		}
+
+		printf( "%s users queued for deletion.", $this->num_queued_users );
+		die();
+	}
+
+	/**
+	 * Check if user exists in smex
+	 * 
+	 * @param  WP_User $user
+	 * @return void
+	 */
+	private function check_user_against_smex( $user ) {
+
+		$username = $user->user_login;
+		printf( "Checking user against smex: %s <br>", $username );
+
+		$smex_user_exists = SK_SMEX_API::get_instance()->user_exists( $username );
+
+		if ( !is_wp_error( $smex_user_exists ) && false === $smex_user_exists ) {
+			$this->maybe_set_deletion_meta( $user );
+			$this->num_queued_users += 1;
+		} else {
+			printf( "User exists.<br>" );
+			delete_user_meta( $user->ID, '_user_deletion_queue');
+		}
+	}
+
+	/**
+	 * Set deletion meta (current timestamp) if not present on the user.
+	 * 
+	 * @param  WP_User $user
+	 * @return void
+	 */
+	private function maybe_set_deletion_meta( $user ) {
+		if ( !$user ) {
+			return false;
+		}
+
+		$deletion_meta = $user->get( '_user_deletion_queue' );
+		if ( empty( $deletion_meta ) ) {
+			$user->get( '_user_deletion_queue' );
+			add_user_meta( $user->ID, '_user_deletion_queue', time(), true);
+		} else {
+	
+		}
+	}
+
+	/**
+	 * Delete users that should be deleted.
+	 * 
+	 * @return void
+	 */
+	private function delete_queued_users() {
+
+		$users = $this->get_users_for_deletion();
+
+		foreach ( $users as $user ) {
+			$this->delete_user( $user ) ? $this->num_deleted_users += 1 : false;
+		}
+
+		printf( "%s users deleted.", $this->num_deleted_users );
+		die();
+	}
+
+	/**
+	 * Delete a WP_User
+	 * 
+	 * @param  WP_User $user
+	 * @return bool
+	 */
+	private function delete_user( $user ) {
+		require_once(ABSPATH.'wp-admin/includes/user.php');
+		return wp_delete_user( $user->ID );
+	}
+}

--- a/plugins/sk-remove-inactive-users/includes/class-sk-remove-inactive-users.php
+++ b/plugins/sk-remove-inactive-users/includes/class-sk-remove-inactive-users.php
@@ -90,7 +90,6 @@ class SK_Remove_Inactive_Users {
 	private function check_user_against_smex( $user ) {
 
 		$username = $user->user_login;
-		printf( "Checking user against smex: %s <br>", $username );
 
 		$smex_user_exists = SK_SMEX_API::get_instance()->user_exists( $username );
 
@@ -98,7 +97,6 @@ class SK_Remove_Inactive_Users {
 			$this->maybe_set_deletion_meta( $user );
 			$this->num_queued_users += 1;
 		} else {
-			printf( "User exists.<br>" );
 			delete_user_meta( $user->ID, '_user_deletion_queue');
 		}
 	}
@@ -118,8 +116,6 @@ class SK_Remove_Inactive_Users {
 		if ( empty( $deletion_meta ) ) {
 			$user->get( '_user_deletion_queue' );
 			add_user_meta( $user->ID, '_user_deletion_queue', time(), true);
-		} else {
-	
 		}
 	}
 

--- a/plugins/sk-remove-inactive-users/sk-remove-inactive-users.php
+++ b/plugins/sk-remove-inactive-users/sk-remove-inactive-users.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Sundsvall Kommun Remove Inactive Users
+ *
+ * @link     http://www.fmca.se/
+ * @package
+ *
+ * @wordpress-plugin
+ * Plugin Name:		SK Remove Inactive Users
+ * Plugin URI:		utveckling.sundsvall.se
+ * Description:		Provides functionality to remove users that is no longer available in SMEX.
+ * Version:			20181128
+ * Author:			SK/FMCA
+ * Author URI:		http://www.fmca.se/
+ * Developer:		FMCA
+ * Developer URI:	utveckling.sundsvall.se
+ * Text Domain:		sk-ria
+ * Domain Path:		/languages
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if acccessed directly.
+}
+
+// Include main plugin class.
+require_once __DIR__ . '/includes/class-sk-remove-inactive-users.php';
+$sk_remove_inactive_users = new SK_Remove_Inactive_Users();

--- a/plugins/sk-smex/includes/class-sk-smex-api.php
+++ b/plugins/sk-smex/includes/class-sk-smex-api.php
@@ -119,6 +119,29 @@ class SK_SMEX_API {
 	}
 
 	/**
+	 * Check if user exists in SMEX
+	 * @param  string $username
+	 * @return bool | WP_Error
+	 */
+	public function user_exists( $username ) {
+		
+		// Make sure we have retrieved user data.
+		if ( $username ) {
+			$soap = $this->get_soap_client();
+			$result = $soap->GetPortalPersonData( array (
+				'loginname'	=> $username,
+			) );
+			if ( empty( $result->GetPortalPersonDataResult ) ) {
+				return false; // User does not exist
+			} else {
+				return true;
+			}
+		} else {
+			return new WP_Error( 'username_not_specified', __( 'Username is not specified.', 'sk-smex' ) );
+		}
+	}
+
+	/**
 	 * Checks if user is required to enter additional fields.
 	 * @return boolean
 	 */


### PR DESCRIPTION
När pluginet är aktiverat finns två url-parametrar:

`/? remove_inactive_users=setup` kollar igenom alla användare och flaggar de som inte längre finns i SMEX med dagens datum (om de inte redan är flaggade). Om de finns i SMEX och var flaggade tas flaggan bort.
`/?remove_inactive_users=delete` tar bort alla användare som var flaggade för minst två veckor sedan.

Dessa kan ni alltså anropa med cron i de intervaller ni vill (t.ex. varje timme).