### PR TITLE
Add new plugin SK Password Resetter

### DIFF
--- a/plugins/sk-password-resetter/includes/class-sk-password-resetter.php
+++ b/plugins/sk-password-resetter/includes/class-sk-password-resetter.php
@@ -1,0 +1,100 @@
+<?php
+/**
+* SK_Password_Resetter
+* ====================
+*
+* Main plugin file.
+*
+* Register hooks and filters.
+*
+* @since   1.0
+* @package SK_Password_Resetter
+*/
+
+class SK_Password_Resetter {
+
+	private $saml_auth_key;
+
+	public function __construct() {
+
+		if ( ! defined( 'AUTH_KEY' ) ) {
+			wp_die( 'No WP Auth-key defined' );
+		}
+
+		$this->saml_auth_key = constant( 'AUTH_KEY' );
+
+		$this->init_hooks();
+	}
+
+	/**
+	* Initiates all action and filter hooks.
+	* @return void
+	*/
+	private function init_hooks() {
+		add_action( 'parse_request', array( $this, 'listener' ) );
+	}
+
+	/**
+	* Our listener that runs certain actions based on GET-parameter.
+	*
+	* @return void
+	*/
+	public function listener() {
+		if ( isset( $_GET['reset_passwords'] ) ) {
+			switch ( $_GET['reset_passwords'] ) {
+				case 'run':
+					$this->reset_passwords();
+					break;
+			}
+		}
+	}
+
+	/**
+	 * Regenerate all users passwords.
+	 *
+	 * @return void
+	 */
+	private function reset_passwords() {
+
+		$args = array(
+			'fields'   => array( 'ID', 'user_login' ),
+		);
+
+		$users = get_users( $args );
+
+		$num_updated = 0;
+
+		foreach ( $users as $user ) {
+			$user_id  = $user->ID;
+			$username = $user->user_login;
+
+			// We don't want to update password for the wpadmin-user.
+			if ( 'wpadmin' === $username ) {
+				continue;
+			}
+
+			$new_pass = $this->user_password( $username, $this->saml_auth_key );
+
+			wp_set_password( $new_pass, $user_id );
+
+			$num_updated += 1;
+		}
+
+		printf( 'Updated password for %s out of %s users.', $num_updated, count( $users ) );
+
+		die();
+	}
+
+	/**
+	 * Generates a SHA-256 HMAC hash using the username and secret key
+	 *
+	 * @param string $value the user's username
+	 * @param string $key a secret key
+	 * @return string
+	 */
+	private function user_password( $value, $key ) {
+		$value = strtolower( $value );
+		$hash  = hash_hmac( 'sha256', $value, $key );
+		return $hash;
+	}
+}

--- a/plugins/sk-password-resetter/sk-password-resetter.php
+++ b/plugins/sk-password-resetter/sk-password-resetter.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * SK Sekretessprodukter
+ * 
+ * @link     http://www.fmca.se/
+ * @package  SK_SMEX
+ *
+ * @wordpress-plugin
+ * Plugin Name:		SK Password Resetter
+ * Plugin URI:		http://www.fmca.se/
+ * Description:		Used to reset the password for all users except the one called "wpadmin". This is needed because of a change done to the SSO-plugin which makes sure that all passwords are being checked by the username in lowercase. Because of this we need to make sure all passwords in the DB is store based on these conditions. Regenerate plugins by visiting the url /?reset_passwords=run while the plugin is active.
+ * Version:			1.0
+ * Author:			FMCA
+ * Author URI:		http://www.fmca.se/
+ * Developer:		FMCA
+ * Developer URI:	http://www.fmca.se/
+ * Text Domain:		sk-password-resetter
+ * Domain Path:		/languages
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if acccessed directly.
+}
+
+// Include main plugin class.
+require_once __DIR__ . '/includes/class-sk-password-resetter.php';
+$sk_password_resetter = new SK_Password_Resetter();


### PR DESCRIPTION
Used to reset the password for all users except the one called
"wpadmin". This is needed because of a change done to the SSO-plugin
which makes sure that all passwords are being checked by the username in
lowercase. Because of this we need to make sure all passwords in the DB
is store based on these conditions.