### PR TITLE
Fix order status issue with free orders in internal order system

### DIFF
--- a/plugins/sk-internal-order/includes/class-skios.php
+++ b/plugins/sk-internal-order/includes/class-skios.php
@@ -41,6 +41,7 @@ class SKIOS {
 
 		// Fix for free orders that otherwise never go through the gateway.
 		add_filter( 'woocommerce_cart_needs_payment', '__return_true', 747 );
+		add_filter( 'woocommerce_order_needs_payment', '__return_true', 747 );
 	}
 
 	/**


### PR DESCRIPTION
**Add filter 'woocommerce_order_needs_payment'**
This is needeed to go through the payment gateway for "free" orders in newer versions of WC