### PR TITLE
Empty pob string for company user

### DIFF
--- a/plugins/sk-internal-order/includes/skios-product-owner-functions.php
+++ b/plugins/sk-internal-order/includes/skios-product-owner-functions.php
@@ -487,6 +487,16 @@ function get_tele2_string( $order, $item ) {
 		$values[] = $pob_string_data[ $key ][ 'meta_val' ];
 	}
 
+	/**
+	 * Return NULL if the user is a "bolagsanvändare"
+	 */
+	$api = SK_SMEX_API::get_instance();
+	$requires_additional_fields = $api::user_requires_additional_fields();
+
+	if ( ! is_wp_error( $requires_additional_fields ) && ! $requires_additional_fields ) {
+		return 'NULL';
+	}
+
 	$string .= implode( ',', $values );
 	$string .= '</span>';
 
@@ -509,6 +519,16 @@ function get_pob_string( $order, $item ) {
 		// POB expect all fields to be outputted with same ammount of
 		// spaces as expected data length if data is missing.
 		$pob_string[] = str_pad( $data['meta_val'], $data['length'], ' ' );
+	}
+
+	/**
+	 * Return empty string if the user is a "bolagsanvändare"
+	 */
+	$api = SK_SMEX_API::get_instance();
+	$requires_additional_fields = $api::user_requires_additional_fields();
+
+	if ( ! is_wp_error( $requires_additional_fields ) && ! $requires_additional_fields ) {
+		return '';
 	}
 
 	// Add a space between every data field.

--- a/plugins/sk-internal-order/includes/skios-product-owner-functions.php
+++ b/plugins/sk-internal-order/includes/skios-product-owner-functions.php
@@ -491,7 +491,7 @@ function get_tele2_string( $order, $item ) {
 	 * Return NULL if the user is a "bolagsanvändare"
 	 */
 	$api = SK_SMEX_API::get_instance();
-	$requires_additional_fields = $api::user_requires_additional_fields();
+	$requires_additional_fields = $api->user_requires_additional_fields();
 
 	if ( ! is_wp_error( $requires_additional_fields ) && ! $requires_additional_fields ) {
 		return 'NULL';
@@ -525,7 +525,7 @@ function get_pob_string( $order, $item ) {
 	 * Return empty string if the user is a "bolagsanvändare"
 	 */
 	$api = SK_SMEX_API::get_instance();
-	$requires_additional_fields = $api::user_requires_additional_fields();
+	$requires_additional_fields = $api->user_requires_additional_fields();
 
 	if ( ! is_wp_error( $requires_additional_fields ) && ! $requires_additional_fields ) {
 		return '';

--- a/plugins/sk-smex/includes/class-sk-smex-api.php
+++ b/plugins/sk-smex/includes/class-sk-smex-api.php
@@ -205,9 +205,10 @@ class SK_SMEX_API {
 	 * @return boolean
 	 */
 	public function user_requires_additional_fields() {
+		$company_id = $this->get_user_data( 'CompanyId' );
 		// First check company id to make sure user
 		// belongs to Sundsvalls Kommun.
-		if ( (int) $this->get_user_data( 'CompanyId' ) !== 1 ) {
+		if ( is_wp_error( $company_id ) || (int) $this->get_user_data( 'CompanyId' ) !== 1 ) {
 			return false;
 		} else {
 			/**


### PR DESCRIPTION
Om extrafält i kassan inte krävs för användaren, returnera NULL för tele2 kostnadsställe och tom sträng för Servicecenter IT kostnadsställe.